### PR TITLE
Legacy javascript polyfills

### DIFF
--- a/lib/polyfills/next-polyfill-module-modern.js
+++ b/lib/polyfills/next-polyfill-module-modern.js
@@ -1,0 +1,14 @@
+// The default Next.js polyfill-module includes several APIs that are already
+// available in the browsers this app targets. Keep only URL.canParse, which is
+// still missing in part of Next.js' default support matrix (for example
+// Chrome 111 and Safari 16.4).
+if (typeof URL !== 'undefined' && !('canParse' in URL)) {
+  URL.canParse = function canParse(url, base) {
+    try {
+      new URL(url, base)
+      return true
+    } catch {
+      return false
+    }
+  }
+}

--- a/lib/polyfills/next-polyfill-nomodule-modern.js
+++ b/lib/polyfills/next-polyfill-nomodule-modern.js
@@ -1,0 +1,3 @@
+// This app no longer serves a legacy no-module bundle. Keeping this file as a
+// no-op prevents Next.js from copying a large compatibility polyfill chunk that
+// only targets browsers outside the support policy.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,15 +1,38 @@
 import path from 'node:path'
 import type { NextConfig } from 'next'
 
+const modernNextPolyfillModule = path.resolve(
+  __dirname,
+  'lib/polyfills/next-polyfill-module-modern.js'
+)
+const modernNextPolyfillModuleForTurbopack = './lib/polyfills/next-polyfill-module-modern.js'
+const nextPolyfillModuleRequests = [
+  '../build/polyfills/polyfill-module',
+  '../build/polyfills/polyfill-module.js',
+  'next/dist/build/polyfills/polyfill-module',
+  'next/dist/build/polyfills/polyfill-module.js',
+]
+const nextPolyfillModuleAliasesForTurbopack = Object.fromEntries(
+  nextPolyfillModuleRequests.map(request => [request, modernNextPolyfillModuleForTurbopack])
+)
+
 /** @type {import('next').NextConfig} */
 const nextConfig: NextConfig = {
   reactStrictMode: true,
-  // Next.js 16 默认使用 Turbopack；保留 webpack 以兼容 --webpack 或构建
-  turbopack: {},
-  webpack: (config, { isServer }) => {
+  // 将 Next 默认的 module polyfills 缩减到仅保留当前目标浏览器仍缺失的 URL.canParse。
+  turbopack: {
+    resolveAlias: nextPolyfillModuleAliasesForTurbopack,
+  },
+  webpack: config => {
     config.resolve ??= {}
     config.resolve.alias ??= {}
     config.resolve.alias['@'] = path.join(__dirname)
+    Object.assign(
+      config.resolve.alias,
+      Object.fromEntries(
+        nextPolyfillModuleRequests.map(request => [`${request}$`, modernNextPolyfillModule])
+      )
+    )
     return config
   },
   images: {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "postinstall": "node scripts/patch-next-polyfills.mjs",
     "lint": "eslint .",
     "type-check": "tsc --noEmit",
     "format:check": "prettier --check .",

--- a/scripts/patch-next-polyfills.mjs
+++ b/scripts/patch-next-polyfills.mjs
@@ -1,0 +1,23 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const currentFile = fileURLToPath(import.meta.url)
+const rootDir = path.resolve(path.dirname(currentFile), '..')
+
+const replacements = [
+  {
+    source: path.join(rootDir, 'lib/polyfills/next-polyfill-module-modern.js'),
+    target: path.join(rootDir, 'node_modules/next/dist/build/polyfills/polyfill-module.js'),
+  },
+  {
+    source: path.join(rootDir, 'lib/polyfills/next-polyfill-nomodule-modern.js'),
+    target: path.join(rootDir, 'node_modules/next/dist/build/polyfills/polyfill-nomodule.js'),
+  },
+]
+
+for (const { source, target } of replacements) {
+  const contents = await readFile(source, 'utf8')
+  await writeFile(target, contents)
+  console.log(`patched ${path.relative(rootDir, target)}`)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Reduces Next.js's default legacy polyfills to eliminate 13 KiB of unnecessary JavaScript for modern browsers reported by Lighthouse.

Next.js injects a significant polyfill bundle (`polyfill-module.js` and `polyfill-nomodule.js`) by default, even for browsers that natively support features like `Array.prototype.at`, `Object.hasOwn`, and `String.prototype.trimStart/End`. Since there's no direct configuration to disable these, this PR implements a workaround using build aliases and a `postinstall` script to replace Next.js's default polyfill files with minimal versions, retaining only `URL.canParse` for broader compatibility.

---
<p><a href="https://cursor.com/agents/bc-a1e7159e-49f7-42ad-982b-df6ce79b1780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1e7159e-49f7-42ad-982b-df6ce79b1780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->